### PR TITLE
ViewRessource : Infolist & relation manager #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ This trait will add the sidebar to the Page.
 // ...
 use AymanAlhattami\FilamentPageWithSidebar\Traits\HasPageSidebar;
 
-class ViewPerson extends ViewRecord
+class ViewUser extends ViewRecord
 {
     use HasPageSidebar;
 
-    protected static string $resource = PersonResource::class;
+    protected static string $resource = UserResource::class;
 
     protected function getHeaderActions(): array
     {

--- a/README.md
+++ b/README.md
@@ -123,13 +123,7 @@ use AymanAlhattami\FilamentPageWithSidebar\Traits\HasPageSidebar;
 
 class ViewUser extends ViewRecord
 {
-    use HasPageSidebar;
-
-    /**
-     * $viewSidebar
-     * override $view when HasPageSidebar is activated
-     */
-    // protected static string $viewSidebar = 'filament.[...].user-resource.pages.view-user';
+    use HasPageSidebar; // use this trait to activate the Sidebar
 
     protected static string $resource = UserResource::class;
 
@@ -142,7 +136,7 @@ class ViewUser extends ViewRecord
 }
 ```
 
-You can still overwritte the default view with ```protected static string $viewSidebar = 'filament.[...].user-resource.pages.view-user';```
+You can still overwritte the default view with ```protected static string $hasSidebar = false;``` with ```protected static $view = 'filament.[...].user-resource.pages.view-user';```
 
 
 ## More Options

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ class ViewUser extends ViewRecord
 {
     use HasPageSidebar;
 
+    /**
+     * $viewSidebar
+     * override $view when HasPageSidebar is activated
+     */
+    // protected static string $viewSidebar = 'filament.[...].user-resource.pages.view-user';
+
     protected static string $resource = UserResource::class;
 
     protected function getHeaderActions(): array
@@ -135,6 +141,9 @@ class ViewUser extends ViewRecord
     }
 }
 ```
+
+You can still overwritte the default view with ```protected static string $viewSidebar = 'filament.[...].user-resource.pages.view-user';```
+
 
 ## More Options
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ class UserResource extends Resource
 
 ```
 
-or add the trait ```AymanAlhattami\FilamentPageWithSidebar\Traits\HasPageSidebar``` on any page you wan the sidebar included.
-This trait will add the sidebar to the Page.
+or add the trait ```AymanAlhattami\FilamentPageWithSidebar\Traits\HasPageSidebar``` on any page you want the sidebar included.
+This trait will add the sidebar to the Page. Add it to all your Resource Pages :
 
 ```php
 // ...
@@ -136,7 +136,7 @@ class ViewUser extends ViewRecord
 }
 ```
 
-You can still overwritte the default view with ```protected static string $hasSidebar = false;``` with ```protected static $view = 'filament.[...].user-resource.pages.view-user';```
+If you wan to use custom view, you can still overwrite the default value with ```protected static string $hasSidebar = false;``` and ```protected static $view = 'filament.[...].user-resource.pages.view-user';```
 
 
 ## More Options

--- a/README.md
+++ b/README.md
@@ -114,6 +114,28 @@ class UserResource extends Resource
 
 ```
 
+or add the trait ```AymanAlhattami\FilamentPageWithSidebar\Traits\HasPageSidebar``` on any page you wan the sidebar included.
+This trait will add the sidebar to the Page.
+
+```php
+// ...
+use AymanAlhattami\FilamentPageWithSidebar\Traits\HasPageSidebar;
+
+class ViewPerson extends ViewRecord
+{
+    use HasPageSidebar;
+
+    protected static string $resource = PersonResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}
+```
+
 ## More Options
 
 ### Set title and description for sidebar

--- a/resources/views/proxy.blade.php
+++ b/resources/views/proxy.blade.php
@@ -1,0 +1,3 @@
+<x-filament-page-with-sidebar::page>
+    @include($this->getIncludedSidebarView())
+</x-filament-page-with-sidebar::page>

--- a/src/Traits/HasPageSidebar.php
+++ b/src/Traits/HasPageSidebar.php
@@ -8,8 +8,10 @@ trait HasPageSidebar
      * public function mountHasPageSidebar
      *   Register automatically view if available
      */
-    public function mountHasPageSidebar(): void
+    public function bootHasPageSidebar(): void
     {
+        // Why boot ? https://livewire.laravel.com/docs/lifecycle-hooks#boot
+
         // Using ${'view'} instead of $view in order to avoid Intelephense warning
         if (isset(static::${'viewSidebar'})) {
             static::${'view'} = static::${'viewSidebar'};

--- a/src/Traits/HasPageSidebar.php
+++ b/src/Traits/HasPageSidebar.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace AymanAlhattami\FilamentPageWithSidebar\Traits;
+
+trait HasPageSidebar
+{
+    /**
+     * public function mountHasPageSidebar
+     *   Register automatically view if available
+     */
+    public function mountHasPageSidebar(): void
+    {
+        // Using ${'view'} instead of $view in order to avoid Intelephense warning
+        if (isset(static::${'view'})) {
+            static::${'view'} = 'filament-page-with-sidebar::proxy';
+        }
+    }
+
+    /**
+     * public function getIncludedSidebarView
+     *   Return string include view
+     */
+    public function getIncludedSidebarView(): string
+    {
+        return collect(class_parents($this))
+            ->filter(function ($class) {
+                return is_subclass_of($class, '\Filament\Pages\Page');
+            })
+            ->map(function ($class) {
+                return (new \ReflectionClass($class))->getDefaultProperties()['view'] ?? null;
+            })
+            ->filter()
+            ->first()
+            ?: throw new \Exception('No view detected for the Sidebar. Implement Filament\Pages\Page object with valid static $view');
+    }
+}

--- a/src/Traits/HasPageSidebar.php
+++ b/src/Traits/HasPageSidebar.php
@@ -11,7 +11,9 @@ trait HasPageSidebar
     public function mountHasPageSidebar(): void
     {
         // Using ${'view'} instead of $view in order to avoid Intelephense warning
-        if (isset(static::${'view'})) {
+        if (isset(static::${'viewSidebar'})) {
+            static::${'view'} = static::${'viewSidebar'};
+        } elseif (isset(static::${'view'})) {
             static::${'view'} = 'filament-page-with-sidebar::proxy';
         }
     }
@@ -22,15 +24,17 @@ trait HasPageSidebar
      */
     public function getIncludedSidebarView(): string
     {
-        return collect(class_parents($this))
-            ->filter(function ($class) {
-                return is_subclass_of($class, '\Filament\Pages\Page');
-            })
-            ->map(function ($class) {
-                return (new \ReflectionClass($class))->getDefaultProperties()['view'] ?? null;
-            })
-            ->filter()
-            ->first()
-            ?: throw new \Exception('No view detected for the Sidebar. Implement Filament\Pages\Page object with valid static $view');
+        if (is_subclass_of($this, '\Filament\Pages\Page')) {
+            $props = collect(
+                (new \ReflectionClass($this))->getDefaultProperties()
+            );
+
+            if ($props->get('view')) {
+                return $props->get('view');
+            }
+        }
+
+        // Else:
+        throw new \Exception('No view detected for the Sidebar. Implement Filament\Pages\Page object with valid static $view');
     }
 }

--- a/src/Traits/HasPageSidebar.php
+++ b/src/Traits/HasPageSidebar.php
@@ -5,24 +5,35 @@ namespace AymanAlhattami\FilamentPageWithSidebar\Traits;
 trait HasPageSidebar
 {
     /**
+     * Activate or not the automatic sidebar to the page
+     * If you change it to FALSE then add manually the $view
+     *  parameter
+     * @var boolean
+     */
+
+    public static bool $hasSidebar = true;
+
+    /**
      * public function mountHasPageSidebar
-     *   Register automatically view if available
+     * 
+     *   Register automatically view if available and activated
      */
     public function bootHasPageSidebar(): void
     {
         // Why boot ? https://livewire.laravel.com/docs/lifecycle-hooks#boot
 
         // Using ${'view'} instead of $view in order to avoid Intelephense warning
-        if (isset(static::${'viewSidebar'})) {
-            static::${'view'} = static::${'viewSidebar'};
-        } elseif (isset(static::${'view'})) {
+        if (static::$hasSidebar) {
             static::${'view'} = 'filament-page-with-sidebar::proxy';
         }
     }
 
     /**
      * public function getIncludedSidebarView
-     *   Return string include view
+     * 
+     *   Return the view that will be used in the sidebar proxy.
+     * 
+     * @Return string \Filament\Pages\Page View to be included
      */
     public function getIncludedSidebarView(): string
     {


### PR DESCRIPTION
A possible solution about the issue #16 

```
Another idea (will test tonight), could be to call an @include of the corresponding view object (specified as constant or dynamically determined).

<x-filament-page-with-sidebar::page>
    @include($this->getChildComponentView())
</x-filament-page-with-sidebar::page>
And getChildComponentView could be a [ReflectionClass::getDefaultProperties](https://www.php.net/manual/en/reflectionclass.getdefaultproperties.php) to get the parent default value's $view of the component.
```

Implement like this, without creating any view:

```php
// ...
use AymanAlhattami\FilamentPageWithSidebar\Traits\HasPageSidebar;

class ViewUser extends ViewRecord
{
    use HasPageSidebar;

    /**
     * $viewSidebar
     * override $view when HasPageSidebar is activated
     */
    // protected static string $viewSidebar = 'filament.[...].user-resource.pages.view-user';

    protected static string $resource = UserResource::class;

    protected function getHeaderActions(): array
    {
        return [
            Actions\EditAction::make(),
        ];
    }
}
```

Tested with Infolist & Edit.

Feel free to improve.