### PR TITLE
Allow PageNavigationItem::label closure

### DIFF
--- a/src/FilamentPageSidebar.php
+++ b/src/FilamentPageSidebar.php
@@ -9,8 +9,8 @@ class FilamentPageSidebar
 {
     use EvaluatesClosures;
 
-    protected ?string $title = null;
-    protected ?string $description = null;
+    protected string | Closure | null  $title = null;
+    protected string | Closure | null  $description = null;
     protected array $navigationItems;
 
     public function __construct()
@@ -23,19 +23,19 @@ class FilamentPageSidebar
     }
 
 
-    public function setTitle(Closure | string $title): static
+    public function setTitle(string | Closure $title): static
     {
-        $this->title = $this->evaluate($title);
+        $this->title = $title;
 
         return $this;
     }
 
-    public function getTitle(): ?string
+    public function getTitle(): string
     {
-        return $this->title;
+        return $this->evaluate($this->title);
     }
 
-    public function setDescription(Closure | string $description): static
+    public function setDescription(string | Closure $description): static
     {
         $this->description = $this->evaluate($description);
 
@@ -44,7 +44,7 @@ class FilamentPageSidebar
 
     public function getDescription(): ?string
     {
-        return $this->description;
+        return $this->evaluate($this->description);
     }
 
     public function setNavigationItems(array $navigationItems): static

--- a/src/FilamentPageSidebar.php
+++ b/src/FilamentPageSidebar.php
@@ -2,8 +2,13 @@
 
 namespace AymanAlhattami\FilamentPageWithSidebar;
 
+use Closure;
+use Filament\Support\Concerns\EvaluatesClosures;
+
 class FilamentPageSidebar
 {
+    use EvaluatesClosures;
+
     protected ?string $title = null;
     protected ?string $description = null;
     protected array $navigationItems;
@@ -16,11 +21,11 @@ class FilamentPageSidebar
     {
         return new static();
     }
-    
 
-    public function setTitle(string $title): static
+
+    public function setTitle(Closure | string $title): static
     {
-        $this->title = $title;
+        $this->title = $this->evaluate($title);
 
         return $this;
     }
@@ -30,9 +35,9 @@ class FilamentPageSidebar
         return $this->title;
     }
 
-    public function setDescription(string $description): static
+    public function setDescription(Closure | string $description): static
     {
-        $this->description = $description;
+        $this->description = $this->evaluate($description);
 
         return $this;
     }

--- a/src/PageNavigationItem.php
+++ b/src/PageNavigationItem.php
@@ -25,8 +25,10 @@ class PageNavigationItem extends NavigationItem
 
     public function getLabel(): string
     {
-        return (is_string($this->label) && $this->shouldTranslateLabel)
-            ? __($this->label)
-            :  $this->label;
+        $label = parent::getLabel();
+
+        return (is_string($label) && $this->shouldTranslateLabel)
+            ? __($label)
+            : $label;
     }
 }


### PR DESCRIPTION
Hello,

It's not possible, to use dynamic closure on the **label** attribute of PageNavigationItem.

```php
    public static function sidebar(Model $record): FilamentPageSidebar
    {
        return FilamentPageSidebar::make()
            ->setTitle($record)
            ->setDescription('Long text')
            ->setNavigationItems([
                PageNavigationItem::make('Dashboard')
                    ->label(fn () => __($record->kind . ' dashboard')) // Dynamic label
                    ->label(fn () => static::getUrl('view', ['record' => $record->id]) );
                    ->icon('heroicon-o-bookmark'),

                PageNavigationItem::make('Organization')
                    ->label('Organization') // Fixed string label
                    ->label(fn () => static::getUrl('org', ['record' => $record->id]) );
                    ->icon('heroicon-o-user-group'),
            ]);
    }

```

Calling the parent method, to benefit of ```evaluate``` method (NavigationItem::getLabel).

![image](https://github.com/aymanalhattami/filament-page-with-sidebar/assets/1201486/551c4800-33b0-4c0d-abb3-adea11e22c45)

By the way, maybe evaluate can be used for isHiddenWhen ?


```php
    public function isHiddenWhen(Closure|bool $condition): static
    {
        $this->isHidden = $this->evaluate($condition);

        return $this;
    }
```