### PR TITLE
Fix wire:navigate

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,28 +141,6 @@ If you wan to use custom view, you can still overwrite the default value with ``
 
 ## More Options
 
-### Enable Wire navigation
-Add wireNavigate to make navigation similar to an SPA (uses wire:navigate under the hood).
-```php
-// ...
-
-public static function sidebar(Model $record): FilamentPageSidebar
-{
-    return FilamentPageSidebar::make()
-        ->wireNavigate()
-        ->setNavigationItems([
-            PageNavigationItem::make(__('User Dashboard'))
-                ->url(function () use ($record) {
-                    return static::getUrl('dashboard', ['record' => $record->id]);
-                }),
-
-            // ... more items
-        ]);
-}
-
-// ...
-```
-
 ### Set title and description for sidebar
 You can set the title or description by using setTitle, setDescription, setDescriptionCopyable methods for the sidebar that will be at the beginning of the sidebar on the top, for example 
 ```php

--- a/resources/views/components/item.blade.php
+++ b/resources/views/components/item.blade.php
@@ -8,7 +8,6 @@
     'first' => false,
     'icon' => null,
     'shouldOpenUrlInNewTab' => false,
-    'isWireNavigate' => false,
     'url',
 ])
 
@@ -19,12 +18,7 @@
     ])
 >
     <a
-        href="{{ $url }}"
-        @if ($shouldOpenUrlInNewTab)
-            target="_blank"
-        @elseif ($isWireNavigate)
-            wire:navigate
-        @endif
+            {{ \Filament\Support\generate_href_html($url, $shouldOpenUrlInNewTab) }}
         x-on:click="window.matchMedia(`(max-width: 1024px)`).matches && $store.sidebar.close()"
         @if (filament()->isSidebarCollapsibleOnDesktop())
             x-data="{ tooltip: false }"

--- a/src/FilamentPageSidebar.php
+++ b/src/FilamentPageSidebar.php
@@ -50,7 +50,7 @@ class FilamentPageSidebar
         return $this->evaluate($this->description);
     }
 
-    public function setDescriptionCopyable(bool | Closure $copyable): static
+    public function setDescriptionCopyable(bool | Closure $copyable = true): static
     {
         $this->descriptionCopyable = $copyable;
 

--- a/src/FilamentPageSidebar.php
+++ b/src/FilamentPageSidebar.php
@@ -16,7 +16,6 @@ class FilamentPageSidebar
     protected string | Closure | null  $description = null;
     protected bool | Closure $descriptionCopyable = false;
     protected array $navigationItems;
-    protected bool | Closure $isWireNavigate = false;
 
     public function __construct()
     {
@@ -133,17 +132,5 @@ class FilamentPageSidebar
                 return $sort;
             })
             ->all();
-    }
-
-    public function wireNavigate(bool | Closure $isWireNavigate = true): static
-    {
-        $this->isWireNavigate = $this->evaluate($isWireNavigate);
-
-        return $this;
-    }
-
-    public function isWireNavigate(): bool
-    {
-        return $this->isWireNavigate;
     }
 }


### PR DESCRIPTION
Removed the wireNavigate logic because the filament helper alone is sufficient to open the link with wire:navigate if the user has enabled the ->spa() option on the panel configuration page.

I've submitted a PR to filament to fix the opening in a new tab, which currently doesn't override wire:navigate.

https://github.com/filamentphp/filament/pull/8567