### PR TITLE
Fix: Initialize sidebarWidths variable in page.blade.php

### DIFF
--- a/resources/views/components/page.blade.php
+++ b/resources/views/components/page.blade.php
@@ -1,5 +1,6 @@
 @php
     $sidebar = $this->getSidebar();
+    $sidebarWidths = $this->getSidebarWidths();
 @endphp
 
 <div>


### PR DESCRIPTION
## Description
This pull request addresses an issue where the `sidebarWidths` variable was not properly initialized in the `page.blade.php` file. The problem was resolved by adding the missing line `$sidebarWidths = $this->getSidebarWidths();`.

## Changes Made
- Added initialization of `$sidebarWidths` variable in `page.blade.php`.
